### PR TITLE
lib/grpc: add some error code names

### DIFF
--- a/lib/grpc.php
+++ b/lib/grpc.php
@@ -26,7 +26,7 @@ namespace Grpc {
         case Codes::OK:
           return "OK";
         case Codes::Canceled:
-          return "Canceld";
+          return "Canceled";
         case Codes::InvalidArgument:
           return "InvalidArgument";
         case Codes::DeadlineExceeded:
@@ -35,6 +35,8 @@ namespace Grpc {
           return "NotFound";
         case Codes::AlreadyExists:
           return "AlreadyExists";
+        case Codes::ResourceExhausted:
+          return "ResourceExhausted";
         case Codes::PermissionDenied:
           return "PermissionDenied";
         case Codes::FailedPrecondition:
@@ -45,6 +47,10 @@ namespace Grpc {
           return "OutOfRange";
         case Codes::Unimplemented:
           return "Unimplemented";
+        case Codes::Internal:
+          return "Internal";
+        case Codes::Unavailable:
+          return "Unavailable";
         case Codes::DataLoss:
           return "DataLoss";
         case Codes::Unauthenticated:


### PR DESCRIPTION
I was trying to use ResourceExhausted, but the exception was getting stringified as "unknown"

now error shows:
```
    4267 SOLR:  - grpc exception: ResourceExhausted (8); grpc error: invoke failed with: '' connection state: 'READY' peer: '127.0.0.1:6001' - ms - 23268us
```