### PR TITLE
use hack lambdas instead of php anonymous functions

### DIFF
--- a/protoc-gen-hack/plugin.go
+++ b/protoc-gen-hack/plugin.go
@@ -1431,7 +1431,7 @@ func writeService(w *writer, sdp *desc.ServiceDescriptorProto, pkg string, ns *N
 		if m.isStreaming() && !isReflectionApi {
 			continue
 		}
-		w.p("$handler = function(\\Grpc\\Context $ctx, \\Grpc\\Unmarshaller $u): %s\\Message use ($service) {", libNs)
+		w.p("$handler = (\\Grpc\\Context $ctx, \\Grpc\\Unmarshaller $u): %s\\Message ==> {", libNs)
 		w.p("$in = new %s();", m.InputPhpName)
 		w.p("$u->Unmarshal($in);")
 		w.p("return $service->%s($ctx, $in);", m.PhpName)

--- a/test/gen-src/example1_proto.php
+++ b/test/gen-src/example1_proto.php
@@ -954,7 +954,7 @@ interface ExampleServiceServer {
 
 function ExampleServiceServiceDescriptor(ExampleServiceServer $service): \Grpc\ServiceDesc {
   $methods = vec[];
-  $handler = function(\Grpc\Context $ctx, \Grpc\Unmarshaller $u): \Protobuf\Message use ($service) {
+  $handler = (\Grpc\Context $ctx, \Grpc\Unmarshaller $u): \Protobuf\Message ==> {
     $in = new \foo\bar\example1();
     $u->Unmarshal($in);
     return $service->OneToTwo($ctx, $in);

--- a/test/gen-src/example4_proto.php
+++ b/test/gen-src/example4_proto.php
@@ -204,7 +204,7 @@ interface AndServer {
 
 function AndServiceDescriptor(AndServer $service): \Grpc\ServiceDesc {
   $methods = vec[];
-  $handler = function(\Grpc\Context $ctx, \Grpc\Unmarshaller $u): \Protobuf\Message use ($service) {
+  $handler = (\Grpc\Context $ctx, \Grpc\Unmarshaller $u): \Protobuf\Message ==> {
     $in = new \pb_Class();
     $u->Unmarshal($in);
     return $service->throw($ctx, $in);


### PR DESCRIPTION
Hack is banning php-style anonymous functions: https://hhvm.com/blog/2019/11/06/hhvm-4.30.html
> we are starting to work on deprecating PHP-style anonymous functions (function($num) { return $num * 2; }) in favor of lambdas ($num ==> $num * 2)

This change generates lambdas instead.

Note I couldn't get the build to work - please pull down to test locally.