### PR TITLE
Add to reserved keywords

### DIFF
--- a/protoc-gen-hack/plugin.go
+++ b/protoc-gen-hack/plugin.go
@@ -31,10 +31,16 @@ var (
 	fversion         = flag.Bool("version", false, "print version and exit")
 	reservedKeywords = []string{"eval", "isset", "unset", "empty", "const", "new", "and", "or",
 		"xor", "as", "print", "throw", "array", "instanceof", "trait", "class", "interface", "static", "self",
-		"int", "bool", "classname", "dict", "vec", "dynamic", "float", "keyset", "nothing", "noreturn", "num",
+		"int", "bool", "classname", "dict", "vec", "dynamic", "float", "keyset", "nothing", "noreturn", "num", "enum"
 		"shape", "string", "Vector", "Map", "Set", "varray", "darray", "Awaitable", "Iterable", "Container", "KeyedContainer",
 		"Traversable", "KeyedTraversable", "Iterable", "KeyedIterable", "Iterator", "KeyedIterator", "AsyncIterator",
-		"AsyncKeyedIterator", "AsyncGenerator"}
+		"AsyncKeyedIterator", "AsyncGenerator", "Generator", "FormatString", "BuiltinEnum", "Throwable", "DateTime",
+		"stdClass", "DateTimeImmutable", "Stringish", "XHPChild", "IMemoizeParam", "typename", "IDisposable",
+		"IAsyncDisposable", "ImmVector", "Set", "ImmSet", "ImmMap", "Pair", "ConstVector", "Collection", "ConstMap"
+		"ConstCollection", "ClassAttribute", "EnumAttribute", "TypeAliasAttribute", "FunctionAttribute", "MethodAttribute", 
+		"InstancePropertyAttribute", "StaticPropertyAttribute", "ParameterAttribute", "TypeParameterAttribute", "FileAttribute", 
+		"TypeConstantAttribute", "tuple", "echo", "assert", "fun", "invariant", "invariant_violation", "inst_meth", "class_meth",
+		"meth_caller", "varray_or_darray", "callable", "object", "dynamic", "this", "mixed", "resource", "null"}
 )
 
 func main() {

--- a/protoc-gen-hack/plugin.go
+++ b/protoc-gen-hack/plugin.go
@@ -7,14 +7,15 @@ import (
 	"encoding/base64"
 	"flag"
 	"fmt"
-	"github.com/golang/protobuf/proto"
-	desc "github.com/golang/protobuf/protoc-gen-go/descriptor"
-	ppb "github.com/golang/protobuf/protoc-gen-go/plugin"
 	"io"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/golang/protobuf/proto"
+	desc "github.com/golang/protobuf/protoc-gen-go/descriptor"
+	ppb "github.com/golang/protobuf/protoc-gen-go/plugin"
 )
 
 const (
@@ -29,7 +30,11 @@ var (
 	version          = "undefined" // go build -ldflags "-X main.version=1"
 	fversion         = flag.Bool("version", false, "print version and exit")
 	reservedKeywords = []string{"eval", "isset", "unset", "empty", "const", "new", "and", "or",
-		"xor", "as", "print", "throw", "array", "instanceof", "trait", "class", "interface", "static", "self"}
+		"xor", "as", "print", "throw", "array", "instanceof", "trait", "class", "interface", "static", "self",
+		"int", "bool", "classname", "dict", "vec", "dynamic", "float", "keyset", "nothing", "noreturn", "num",
+		"shape", "string", "Vector", "Map", "Set", "varray", "darray", "Awaitable", "Iterable", "Container", "KeyedContainer",
+		"Traversable", "KeyedTraversable", "Iterable", "KeyedIterable", "Iterator", "KeyedIterator", "AsyncIterator",
+		"AsyncKeyedIterator", "AsyncGenerator"}
 )
 
 func main() {

--- a/protoc-gen-hack/plugin.go
+++ b/protoc-gen-hack/plugin.go
@@ -244,7 +244,7 @@ func toPhpName(ns, name string) (string, string) {
 func isReservedName(name string) bool {
 	lowerName := strings.ToLower(name)
 	for _, keyword := range reservedKeywords {
-		if lowerName == keyword {
+		if lowerName == strings.ToLower(keyword) {
 			return true
 		}
 	}


### PR DESCRIPTION
It is no longer possible to declare types that overrides existing builtins since HHVM 4.28, so we need to add to the list of reserved keywords to avoid possible collisions.

https://hhvm.com/blog/2019/10/23/hhvm-4.28.html
> Declaring a type with the same name as a built-in type (e.g. int, Vector, Awaitable) will no longer override the built-in type. Such types can now only be referenced using their namespaced name (e.g. MyNamespace\Vector, or namespace\Vector if in the same namespace).

https://hhvm.com/blog/2019/11/06/hhvm-4.30.html
> it is no longer possible to override built-in types using use statements (use MyVector as Vector, use MyType as string, etc.)

This PR adds a list of reserved keywords (possibly might be missing some?). Also ran gofmt over `plugin.go`

A list of reserved words can be found at https://github.com/facebook/hhvm/blob/master/hphp/hack/src/naming/naming_special_names.rs