### PR TITLE
add namespace to reserved keywords list

### DIFF
--- a/protoc-gen-hack/plugin.go
+++ b/protoc-gen-hack/plugin.go
@@ -40,7 +40,7 @@ var (
 		"ConstCollection", "ClassAttribute", "EnumAttribute", "TypeAliasAttribute", "FunctionAttribute", "MethodAttribute",
 		"InstancePropertyAttribute", "StaticPropertyAttribute", "ParameterAttribute", "TypeParameterAttribute", "FileAttribute",
 		"TypeConstantAttribute", "tuple", "echo", "assert", "fun", "invariant", "invariant_violation", "inst_meth", "class_meth",
-		"meth_caller", "varray_or_darray", "callable", "object", "dynamic", "this", "mixed", "resource", "null"}
+		"meth_caller", "varray_or_darray", "callable", "object", "dynamic", "this", "mixed", "resource", "null", "namespace"}
 )
 
 func main() {


### PR DESCRIPTION
`namespace` is a reserved keyword as of [HHVM 4.47](https://hhvm.com/blog/2020/03/03/hhvm-4.47.html):
> namespace is now a reserved keyword, trying to use it as an identifier will result in a parser error.

this PR adds `namespace` to the list of reserved keywords.