### PR TITLE
handle reserved keywords when writing enums

### DIFF
--- a/protoc-gen-hack/plugin.go
+++ b/protoc-gen-hack/plugin.go
@@ -990,7 +990,7 @@ func (f field) isOneofMember() bool {
 
 // writeEnum writes an enumeration type and constants definitions.
 func writeEnum(w *writer, ed *desc.EnumDescriptorProto, prefixNames []string) {
-	name := strings.Join(append(prefixNames, *ed.Name), "_")
+	name := escapeReservedName(strings.Join(append(prefixNames, *ed.Name), "_"))
 	typename := name + "_enum_t"
 	w.p("newtype %s as int = int;", typename)
 	w.p("abstract class %s {", name)


### PR DESCRIPTION
reserved keyword escaping is not currently performed when writing enums. this PR adds reserved name escaping when writing enums.

**example proto (note `namespace` is a reserved keyword in HHVM 4.47+):**
```proto
syntax = "proto3";
package test;

enum Namespace {
    ...
}
```

**generated hack before:**
```hack
newtype Namespace_enum_t as int = int;
abstract class Namespace {
...
```

**generated hack after:**
```hack
newtype pb_Namespace_enum_t as int = int;
abstract class pb_Namespace {
...
```